### PR TITLE
Allow components to import svelte lifecycle bits

### DIFF
--- a/src/_site/components/Counter.island.svelte
+++ b/src/_site/components/Counter.island.svelte
@@ -3,7 +3,7 @@
 	import { onMount } from 'svelte'
 
 	export let count = 3
-	let mounted = true
+	let mounted = false
 	onMount(async () => {
 		mounted = true
 	})

--- a/src/_site/components/Counter.island.svelte
+++ b/src/_site/components/Counter.island.svelte
@@ -1,12 +1,16 @@
 <script>
-  import Nested from "./Nested.svelte";
+	import Nested from './Nested.svelte'
+	import { onMount } from 'svelte'
 
-  export let count = 3;
-  const SSR = typeof document === "undefined";
+	export let count = 3
+	let mounted = true
+	onMount(async () => {
+		mounted = true
+	})
 </script>
 
-<button disabled={SSR} on:click={() => count--}> -1 </button>
+<button disabled={!mounted} on:click={() => count--}> -1 </button>
 {count}
-<button disabled={SSR} on:click={() => count++}> +1 </button>
+<button disabled={!mounted} on:click={() => count++}> +1 </button>
 
 <Nested {count} />

--- a/src/esbuild_plugins/resolve_svelte_internal.ts
+++ b/src/esbuild_plugins/resolve_svelte_internal.ts
@@ -5,20 +5,18 @@ const svelte_internal = await fetch(
 );
 const svelte_internal_src = await svelte_internal.text();
 
-const filter = /^svelte\/internal$/;
-
 export const resolve_svelte_internal: Plugin = {
 	name: "svelte/internal",
 	setup(build) {
-		build.onResolve({ filter }, () => {
+		build.onResolve({ filter: /^svelte(\/internal)?$/ }, () => {
 			return {
 				path: "svelte/internal",
-				namespace: "fs-virtual",
+				namespace: "svelte",
 				external: false,
 			};
 		});
 
-		build.onLoad({ filter }, () => {
+		build.onLoad({ filter: /.*/, namespace: "svelte" }, () => {
 			return {
 				contents: svelte_internal_src,
 			};


### PR DESCRIPTION
allows for things like `import { onMount } from 'svelte'` etc (as the docs show)