### PR TITLE
Islands hydrate themselves

### DIFF
--- a/src/_site/components/GreenThenPink.island.svelte
+++ b/src/_site/components/GreenThenPink.island.svelte
@@ -1,13 +1,15 @@
 <script>
+	import { onMount } from 'svelte'
+
 	let green = true
 	let pink = false
 
-	setTimeout(() => {
-		green = false
-		pink = true
-	}, 1000)
-
-	console.log('hello from GreenThenPink.island.svelte')
+	onMount(() => {
+		setTimeout(() => {
+			green = false
+			pink = true
+		}, 1000)
+	})
 </script>
 
 <p class:green class:pink>green then pink</p>

--- a/src/_site/components/RedThenBlue.island.svelte
+++ b/src/_site/components/RedThenBlue.island.svelte
@@ -1,15 +1,16 @@
 <script>
+	import { onMount } from 'svelte'
 	import GreenThenPink from './GreenThenPink.island.svelte'
 
 	let red = true
 	let blue = false
 
-	setTimeout(() => {
-		red = false
-		blue = true
-	}, 1000)
-
-	console.log('hello from RedThenBlue.island.svelte')
+	onMount(() => {
+		setTimeout(() => {
+			red = false
+			blue = true
+		}, 1000)
+	})
 </script>
 
 <p class:red class:blue>red then blue</p>

--- a/src/_site/components/sub_dir/SubDir.island.svelte
+++ b/src/_site/components/sub_dir/SubDir.island.svelte
@@ -1,0 +1,5 @@
+<script>
+	import GreenThenPink from '../../components/GreenThenPink.island.svelte'
+</script>
+
+<GreenThenPink />

--- a/src/_site/routes/nested-islands.svelte
+++ b/src/_site/routes/nested-islands.svelte
@@ -1,9 +1,11 @@
 <script>
 	import RedThenBlue from '../components/RedThenBlue.island.svelte'
 	import GreenThenPink from '../components/GreenThenPink.island.svelte'
+	import SubDir from '../components/sub_dir/SubDir.island.svelte'
 </script>
 
 Example of nested islands.
 
 <RedThenBlue />
 <GreenThenPink />
+<SubDir />

--- a/src/_site/routes/nested-islands.svelte
+++ b/src/_site/routes/nested-islands.svelte
@@ -8,4 +8,5 @@ Example of nested islands.
 
 <RedThenBlue />
 <GreenThenPink />
+<GreenThenPink />
 <SubDir />

--- a/src/build.ts
+++ b/src/build.ts
@@ -61,9 +61,9 @@ const routesESBuildConfig: esbuild.BuildOptions = {
 	entryPoints: await get_svelte_files({ dir: "routes/" }),
 	write: false,
 	plugins: [
-		svelte_components,
+		svelte_components(site_dir, base_path),
 		svelte_internal,
-		build_routes({ base_path }),
+		build_routes,
 	],
 	outdir: build_dir,
 	...baseESBuildConfig,
@@ -73,7 +73,7 @@ const islandsESBuildConfig: esbuild.BuildOptions = {
 	entryPoints: await get_svelte_files({ dir: "components/" }),
 	write: true,
 	plugins: [
-		svelte_components,
+		svelte_components(site_dir, base_path),
 		svelte_internal,
 	],
 	outdir: build_dir + "components/",

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,7 +1,7 @@
 import * as esbuild from "https://deno.land/x/esbuild@v0.17.16/mod.js";
 import { svelte_components } from "./esbuild_plugins/svelte_components.ts";
 import { svelte_internal } from "./esbuild_plugins/svelte_internal.ts";
-import { build_routes } from "./esbuild_plugins/routes.ts";
+import { build_routes } from "./esbuild_plugins/build_routes.ts";
 import { ensureDir } from "https://deno.land/std@0.177.0/fs/ensure_dir.ts";
 import { parse } from "https://deno.land/std@0.177.0/flags/mod.ts";
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";

--- a/src/esbuild_plugins/build_routes.ts
+++ b/src/esbuild_plugins/build_routes.ts
@@ -29,11 +29,17 @@ export const build_routes: Plugin = {
 				const { html, css: _css, head } = module.default.render();
 
 				// remove any duplicate module imports (in cases where a page uses an island more than once)
-				const deduped_head = Array.from(
-					new Set(
-						head.match(/<script type="module">[\s\S]*?<\/script>/g),
-					),
-				).join("\n");
+				const modules = new Set();
+				const deduped_head = head.replace(
+					/<script[\s\S]*?<\/script>/g,
+					(module) => {
+						if (modules.has(module)) {
+							return "";
+						}
+						modules.add(module);
+						return module;
+					},
+				);
 
 				const css = _css?.code ?? "";
 

--- a/src/esbuild_plugins/get_route_html.ts
+++ b/src/esbuild_plugins/get_route_html.ts
@@ -7,33 +7,6 @@ interface TemplateOptions {
 	html: string;
 }
 
-// // this function is stringified inline in the page
-// // putting it here gives us type safety etc
-// export const hydrate_island = (component: SvelteComponent, name: string) => {
-// 	try {
-// 		document.querySelectorAll(
-// 			`one-claw[name='${name}']:not(one-claw one-claw)`,
-// 		).forEach((target, i) => {
-// 			const load = performance.now();
-// 			console.group(
-// 				`Hydrating %c${name}%c (instance #${(i + 1)})`,
-// 				"color: orange",
-// 				"color: reset",
-// 			);
-// 			console.log(target);
-// 			const props = JSON.parse(target.getAttribute("props") ?? "{}");
-// 			new component({ target, props, hydrate: true });
-// 			console.log(
-// 				`Done in %c${Math.round((performance.now() - load) * 1000) / 1000}ms`,
-// 				"color: orange",
-// 			);
-// 			console.groupEnd();
-// 		});
-// 	} catch (_) {
-// 		console.error(_);
-// 	}
-// };
-
 const template = ({ css, head, html }: TemplateOptions) => `
 	<!DOCTYPE html>
 	<html lang="en">

--- a/src/esbuild_plugins/get_route_html.ts
+++ b/src/esbuild_plugins/get_route_html.ts
@@ -1,5 +1,4 @@
 import { format } from "npm:prettier";
-// import type { SvelteComponent } from "https://esm.sh/v115/svelte@3.58.0/types/runtime/index.d.ts";
 
 interface TemplateOptions {
 	css: string;

--- a/src/esbuild_plugins/get_route_html.ts
+++ b/src/esbuild_plugins/get_route_html.ts
@@ -1,50 +1,40 @@
-import { normalize } from "https://deno.land/std@0.177.0/path/mod.ts";
 import { format } from "npm:prettier";
-
-// dummy value to put the var name in scope
-const component_path = "";
-
-// this function is stringified inline in the page
-// putting it here gives us type safety etc
-export const hydrate_island = async (target: Element) => {
-	try {
-		const name = target.getAttribute("name");
-		const props = JSON.parse(target.getAttribute("props") ?? "{}");
-		const load = performance.now();
-
-		const Component =
-			(await import(component_path + name + ".island.js")).default;
-		console.group(name);
-		console.info(
-			`Loaded in %c${Math.round((performance.now() - load) * 1000) / 1000}ms`,
-			"color: orange",
-		);
-
-		const hydrate = performance.now();
-		new Component({ target, props, hydrate: true });
-		target.setAttribute("foraged", "");
-
-		console.info(
-			`Hydrated in %c${
-				Math.round((performance.now() - hydrate) * 1000) / 1000
-			}ms%c with`,
-			"color: orange",
-			"color: reset",
-			props,
-		);
-		console.groupEnd();
-	} catch (_) {
-		console.error(_);
-	}
-};
+// import type { SvelteComponent } from "https://esm.sh/v115/svelte@3.58.0/types/runtime/index.d.ts";
 
 interface TemplateOptions {
 	css: string;
 	head: string;
 	html: string;
-	hydrator: string;
 }
-const template = ({ css, head, html, hydrator }: TemplateOptions) => `
+
+// // this function is stringified inline in the page
+// // putting it here gives us type safety etc
+// export const hydrate_island = (component: SvelteComponent, name: string) => {
+// 	try {
+// 		document.querySelectorAll(
+// 			`one-claw[name='${name}']:not(one-claw one-claw)`,
+// 		).forEach((target, i) => {
+// 			const load = performance.now();
+// 			console.group(
+// 				`Hydrating %c${name}%c (instance #${(i + 1)})`,
+// 				"color: orange",
+// 				"color: reset",
+// 			);
+// 			console.log(target);
+// 			const props = JSON.parse(target.getAttribute("props") ?? "{}");
+// 			new component({ target, props, hydrate: true });
+// 			console.log(
+// 				`Done in %c${Math.round((performance.now() - load) * 1000) / 1000}ms`,
+// 				"color: orange",
+// 			);
+// 			console.groupEnd();
+// 		});
+// 	} catch (_) {
+// 		console.error(_);
+// 	}
+// };
+
+const template = ({ css, head, html }: TemplateOptions) => `
 	<!DOCTYPE html>
 	<html lang="en">
 		<head>
@@ -52,7 +42,6 @@ const template = ({ css, head, html, hydrator }: TemplateOptions) => `
 			<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 			<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 			${head}
-			<script type="module">${hydrator}</script>
 			<style>${css}</style>
 		</head>
 		<body>
@@ -61,23 +50,15 @@ const template = ({ css, head, html, hydrator }: TemplateOptions) => `
 	</html>
 `;
 
-const island_hydrator = (base = "") => `
-	const component_path = "${base}";
-	const hydrate_island = ${hydrate_island.toString()};
-	document.querySelectorAll("one-claw[name]:not(one-claw one-claw)").forEach(hydrate_island);
-`;
-
-export const get_route_html = ({ html, css, head, base_path }: {
+export const get_route_html = ({ html, css, head }: {
 	html: string;
 	css: string;
 	head: string;
-	base_path?: string;
 }) => {
 	const page = template({
 		css,
 		head,
 		html,
-		hydrator: island_hydrator(normalize(`/${base_path}/components/`)),
 	});
 
 	try {

--- a/src/esbuild_plugins/svelte_components.ts
+++ b/src/esbuild_plugins/svelte_components.ts
@@ -100,10 +100,10 @@ export const svelte_components = (
 					try {
 						document.querySelectorAll(
 							`one-claw[name='${name}']:not(one-claw one-claw)`,
-						).forEach((target, i) => {
+						).forEach((target) => {
 							const load = performance.now();
-							console.group(
-								`Hydrating %c${name}%c (instance #${(i + 1)})`,
+							console.groupCollapsed(
+								`Hydrating %c${name}%c`,
 								"color: orange",
 								"color: reset",
 							);

--- a/src/esbuild_plugins/svelte_components.ts
+++ b/src/esbuild_plugins/svelte_components.ts
@@ -4,6 +4,7 @@ import {
 	resolve,
 } from "https://deno.land/std@0.177.0/path/mod.ts";
 import type { Plugin } from "https://deno.land/x/esbuild@v0.17.16/mod.js";
+import { normalize } from "https://deno.land/std@0.177.0/path/mod.ts";
 import { compile } from "npm:svelte/compiler";
 
 const filter = /\.svelte$/;
@@ -12,19 +13,32 @@ const name = "mononykus/svelte";
 /** force wrapping the actual component in a synthetic one */
 const one_claw_synthetic = "?one-claw-synthetic";
 
-const OneClaw = ({ path, name }: { path: string; name: string }) =>
+const OneClaw = (
+	{ path, name, module_src }: {
+		path: string;
+		name: string;
+		module_src: string;
+	},
+) =>
 	`<!-- synthetic component -->
-<script>
-	import Island from "${path}";
-</script>
-<one-claw props={JSON.stringify($$props)} name="${name}">
-	<Island {...$$props} />
-</one-claw>
-<style>
-	one-claw { display: contents }
-</style>`;
+	<script>
+		import Island from "${path}";
+	</script>
+	<svelte:head>
+		<script type="module" src="${module_src}"></script>
+	</svelte:head>
+	<one-claw props={JSON.stringify($$props)} name="${name}">
+		<Island {...$$props} />
+	</one-claw>
+	<style>
+		one-claw { display: contents }
+	</style>
+`;
 
-export const svelte_components: Plugin = {
+export const svelte_components = (
+	site_dir: string,
+	base_path: string,
+): Plugin => ({
 	name,
 	setup(build) {
 		const generate = build.initialOptions.write ? "dom" : "ssr";
@@ -61,8 +75,14 @@ export const svelte_components: Plugin = {
 				.replace(/(\.island)?\.svelte$/, "")
 				.replaceAll(/(\.|\W)/g, "_");
 
+			const module_src = normalize("/" + base_path + path.split(site_dir)[1])
+				.replace(
+					/svelte$/,
+					"js",
+				);
+
 			const source = suffix === one_claw_synthetic
-				? OneClaw({ path, name })
+				? OneClaw({ path, name, module_src })
 				: await Deno.readTextFile(path);
 
 			const { js: { code } } = compile(source, {
@@ -74,7 +94,38 @@ export const svelte_components: Plugin = {
 				filename: basename(path),
 			});
 
+			if (suffix === one_claw_synthetic) {
+				const x = () => {
+					try {
+						document.querySelectorAll(
+							`one-claw[name='${name}']:not(one-claw one-claw)`,
+						).forEach((target, i) => {
+							const load = performance.now();
+							console.group(
+								`Hydrating %c${name}%c (instance #${(i + 1)})`,
+								"color: orange",
+								"color: reset",
+							);
+							console.log(target);
+							const props = JSON.parse(target.getAttribute("props") ?? "{}");
+							// new component({ target, props, hydrate: true });
+							console.log(
+								`Done in %c${
+									Math.round((performance.now() - load) * 1000) / 1000
+								}ms`,
+								"color: orange",
+							);
+							console.groupEnd();
+						});
+					} catch (_) {
+						console.error(_);
+					}
+				};
+
+				return ({ contents: code + x.toString() });
+			}
+
 			return ({ contents: code });
 		});
 	},
-};
+});


### PR DESCRIPTION
rather than the page introspecting for island targets and fetching required the modules, this change will add script tags to the head for each island that will be needed. 

the island module then hydrates all waiting targets itself, once it loads.

## why?

enables the browser pre-parser to start fetching the modules as soon as it encounters them (since we know at compile time which islands will used on the page)