### PR TITLE
External entry points

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -63,7 +63,7 @@ const routesESBuildConfig: esbuild.BuildOptions = {
 	entryPoints: await get_svelte_files({ dir: "routes/" }),
 	write: false,
 	plugins: [
-		island_wrapper("ssr", site_dir),
+		island_wrapper(site_dir),
 		resolve_svelte_internal,
 		build_routes({ base_path }),
 	],
@@ -73,8 +73,9 @@ const routesESBuildConfig: esbuild.BuildOptions = {
 
 const islandsESBuildConfig: esbuild.BuildOptions = {
 	entryPoints: await get_svelte_files({ dir: "components/" }),
+	write: true,
 	plugins: [
-		island_wrapper("dom", site_dir),
+		island_wrapper(site_dir),
 		resolve_svelte_internal,
 	],
 	outdir: build_dir + "components/",

--- a/src/build.ts
+++ b/src/build.ts
@@ -60,10 +60,7 @@ const baseESBuildConfig = {
 } as const satisfies Partial<esbuild.BuildOptions>;
 
 const routesESBuildConfig: esbuild.BuildOptions = {
-	entryPoints: [
-		await get_svelte_files({ dir: "routes/" }),
-	]
-		.flat(),
+	entryPoints: await get_svelte_files({ dir: "routes/" }),
 	write: false,
 	plugins: [
 		island_wrapper("ssr", site_dir),
@@ -75,10 +72,7 @@ const routesESBuildConfig: esbuild.BuildOptions = {
 };
 
 const islandsESBuildConfig: esbuild.BuildOptions = {
-	entryPoints: [
-		await get_svelte_files({ dir: "components/" }),
-	]
-		.flat(),
+	entryPoints: await get_svelte_files({ dir: "components/" }),
 	plugins: [
 		island_wrapper("dom", site_dir),
 		resolve_svelte_internal,


### PR DESCRIPTION
### What does this change?
Simplify the build output by marking islands as external, reducing the number of chunks produced by the bundle splitting.

#### Before

```js
// file: RedThenBlue.island.js
import {
  GreenThenPink_island_default
} from "./chunk-WLNA4ATP.js";

// file: GreenThenPink.island.js
import {
  GreenThenPink_island_default
} from "./chunk-WLNA4ATP.js";
import "./chunk-JA2UCGWR.js";
export {
  GreenThenPink_island_default as default
};

```

#### After

```js
// file: RedThenBlue.island.js
import GreenThenPink from "./GreenThenPink.island.js";

// file: GreenThenPink.island.js
var GreenThenPink_island = class extends SvelteComponent {
  constructor(options) {
    super();
    init(this, options, instance, create_fragment, safe_not_equal, {}, add_css);
  }
};
var GreenThenPink_island_default = GreenThenPink_island;
export {
  GreenThenPink_island_default as default
};
```