### PR TITLE
Simpler island wrapping

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -61,7 +61,7 @@ const routesESBuildConfig: esbuild.BuildOptions = {
 	entryPoints: await get_svelte_files({ dir: "routes/" }),
 	write: false,
 	plugins: [
-		svelte_components(site_dir),
+		svelte_components,
 		svelte_internal,
 		build_routes({ base_path }),
 	],
@@ -73,7 +73,7 @@ const islandsESBuildConfig: esbuild.BuildOptions = {
 	entryPoints: await get_svelte_files({ dir: "components/" }),
 	write: true,
 	plugins: [
-		svelte_components(site_dir),
+		svelte_components,
 		svelte_internal,
 	],
 	outdir: build_dir + "components/",

--- a/src/esbuild_plugins/svelte_components.ts
+++ b/src/esbuild_plugins/svelte_components.ts
@@ -1,69 +1,88 @@
+import {
+	basename,
+	dirname,
+	resolve,
+} from "https://deno.land/std@0.177.0/path/mod.ts";
 import type { Plugin } from "https://deno.land/x/esbuild@v0.17.16/mod.js";
-import { compile, preprocess } from "npm:svelte/compiler";
+import { compile } from "npm:svelte/compiler";
 
 const filter = /\.svelte$/;
 const name = "mononykus/svelte";
 
-export const svelte_components = (dir: string): Plugin => ({
+const OneClaw = ({ path, name }: { path: string; name: string }) =>
+	`<!-- magical wrapper -->
+<script>
+	import Island from "${path}?nested";
+</script>
+<one-claw props={JSON.stringify($$props)} name="${name}">
+	<Island {...$$props} />
+</one-claw>
+<style>
+	one-claw { display: contents }
+</style>`;
+
+export const svelte_components: Plugin = {
 	name,
 	setup(build) {
 		const generate = build.initialOptions.write ? "dom" : "ssr";
 
-		build.onResolve({ filter }, ({ path, kind }) => {
-			const is_island_entry_point = generate === "dom" &&
-				kind === "import-statement" &&
-				// matches our `components/**/*.island.svelte`,
-				// perfect proxy of checking `build.initialOptions.entryPoints`
-				path.endsWith(".island.svelte");
-
-			return is_island_entry_point
-				? {
-					path: path.replace(/\.svelte$/, ".js"),
-					external: true,
+		build.onResolve({ filter }, ({ path, kind, importer }) => {
+			// pattern matching for the rest of us
+			switch (true) {
+				case generate === "dom" &&
+					kind === "import-statement" &&
+					// matches our `components/**/*.island.svelte`,
+					// perfect proxy of checking `build.initialOptions.entryPoints`
+					path.endsWith(".island.svelte"): {
+					return {
+						path: path.replace(/\.svelte$/, ".js"),
+						external: true,
+					};
 				}
-				: undefined;
+				case generate === "ssr" && path.endsWith(".island.svelte?nested"): {
+					return {
+						path: resolve(dirname(importer), path),
+					};
+				}
+				case generate === "ssr" && path.endsWith(".island.svelte"): {
+					return {
+						path: resolve(dirname(importer), path),
+						suffix: "?claw",
+					};
+				}
+				default:
+					return undefined;
+			}
 		});
 
-		build.onLoad({ filter }, async ({ path }) => {
-			const filename = path.split(dir).at(-1) ?? "Undefined.svelte";
+		build.onLoad({ filter }, async ({ path, suffix }) => {
+			const name = basename(path)
+				.replace(/(\.island)?\.svelte$/, "")
+				.replaceAll(/(\.|\W)/g, "_");
+
+			if (suffix === "?claw") {
+				const contents = compile(OneClaw({ path, name }), {
+					generate,
+					css: "injected",
+					cssHash: ({ hash, css }) => `◖${hash(css)}◗`,
+					enableSourcemap: false,
+				}).js.code;
+
+				return { contents };
+			}
+
 			const source = await Deno.readTextFile(path);
-			const island = filename.match(/\/(\w+).island.svelte/);
 
-			const processed = island && generate === "ssr"
-				? (await preprocess(source, {
-					markup: ({ content }) => {
-						let processed = content;
-						const non_html = content.match(
-							/(<style.*>[\s\S]*?<\/style>|<script.*>[\s\S]*?<\/script>)/gm,
-						);
-
-						if (non_html) {
-							let html = content;
-							for (const el of non_html) {
-								html = html.replace(el, "");
-							}
-							processed = non_html.join("") +
-								`<one-claw name="${
-									island[1]
-								}" props={JSON.stringify($$props)} style="display:contents;">${html.trim()}</one-claw>`;
-						}
-						return ({
-							code: processed,
-						});
-					},
-				})).code
-				: source;
-
-			const { js: { code } } = compile(processed, {
+			const { js: { code } } = compile(source, {
 				generate,
 				css: "injected",
 				cssHash: ({ hash, css }) => `◖${hash(css)}◗`,
 				hydratable: generate === "dom",
 				enableSourcemap: false,
-				filename,
+				filename: basename(path),
 			});
 
 			return ({ contents: code });
 		});
 	},
-});
+};


### PR DESCRIPTION
Just wrap islands in a synthetic component.

- less regular expressions
- more using the platform
- ~more performance~ running `hyperfine` there’s actually a 1% slowdown
